### PR TITLE
Use inbuilt functionality to upload app to BrowserStack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,17 @@
   export BROWSERSTACK_ACCESS_KEY=<browserstack-access-key>
   ```
 
-- Upload the apps provided in resources folder using this command 
-```
-  curl -u "<username>:<access-key>" \
-  -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
-  -F "file=@/path/to/app/file/application-debug.apk"
-  ```
-- Please note the value of app_url in the API response and set the app capbility in the `nightwatch.conf.js`, `nightwatch-local.conf.js` and `nightwatch-suite.conf.js` in conf folder for the respective apps.
-  * android_app_url in `browserstack.android_01` and `browserstack.android_02` capability set in nightwatch-suite.conf.js
-  * android_app_url in `browserstack.android_01` capability set in nightwatch.conf.js
-  * ios_app_url in `browserstack.ios_01` capability set in nightwatch.conf.js
-  * android_local_app_url in `browserstack.local_01` and `browserstack.local_02` capability set in nightwatch-local.conf.js
-- Please go through [this](https://www.browserstack.com/docs/app-automate/appium/upload-app-from-filesystem) documentation for better understanding.
 
 ## Running your tests
 
 - To run a single android test, run `npm run single-android`
 - To run a single ios test, run `npm run single-ios`
+- To run local tests, run `npm run local`
+
+Please run the above tests once before running parallel tests, so that the apps can be uploaded on the respective [custom id](https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id).
 - To run parallel tests, run `npm run parallel`
 - To run parallel tests on different devices, run `npm run parallel-devices`
 - To run test suite, run `npm run suite`
-- To run local tests, run `npm run local`
 - To run parallel local tests, run `npm run parallel-local`
 
 

--- a/resources/config/nightwatch-local.conf.js
+++ b/resources/config/nightwatch-local.conf.js
@@ -48,24 +48,27 @@ const nightwatchConfigs = {
         browserName: null,
         'appium:options': {
           automationName: 'UiAutomator2',
-          app: 'bs://<android_local_app_url>',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_android_local_app',
           platformVersion: '9.0',
           deviceName: 'Google Pixel 3'
-        }
+        },
+        appUploadPath: 'apps/android_local_app.apk'
       }
     },
     "browserstack.local_02": {
-        extends: 'browserstack',
-        'desiredCapabilities': {
-          browserName: null,
-          'appium:options': {
-            automationName: 'UiAutomator2',
-            app: 'bs://<android_local_app_url>',
-            platformVersion: '9.0',
-            deviceName: 'Samsung Galaxy S10'
-          }
+      extends: 'browserstack',
+      'desiredCapabilities': {
+        browserName: null,
+        'appium:options': {
+          automationName: 'UiAutomator2',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_android_local_app',
+          platformVersion: '9.0',
+          deviceName: 'Samsung Galaxy S10'
         }
-      },
+      }
+    },
   }
 }
 

--- a/resources/config/nightwatch-suite.conf.js
+++ b/resources/config/nightwatch-suite.conf.js
@@ -46,7 +46,8 @@ const nightwatchConfigs = {
         browserName: null,
         'appium:options': {
           automationName: 'UiAutomator2',
-          app: 'bs://<android_app_url>',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_android_app',
           platformVersion: '11.0',
           deviceName: 'Google Pixel 5'
         }
@@ -58,7 +59,8 @@ const nightwatchConfigs = {
         browserName: null,
         'appium:options': {
           automationName: 'UiAutomator2',
-          app: 'bs://<android_app_url>',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_android_app',
           platformVersion: '11.0',
           deviceName: 'Google Pixel 4'
         }

--- a/resources/config/nightwatch.conf.js
+++ b/resources/config/nightwatch.conf.js
@@ -33,8 +33,6 @@ const nightwatchConfigs = {
     browserstack:  {
       ...browserStack
     },
-    
-    
 
     "browserstack.android_01": {
       extends: 'browserstack',
@@ -42,10 +40,12 @@ const nightwatchConfigs = {
         browserName: null,
         'appium:options': {
           automationName: 'UiAutomator2',
-          app: 'bs://<android_app_url>',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_android_app',
           platformVersion: '11.0',
           deviceName: 'Google Pixel 5'
-        }
+        },
+        appUploadPath: 'apps/android_app.apk'
       }
     },
 
@@ -55,10 +55,12 @@ const nightwatchConfigs = {
         browserName: null,
         'appium:options': {
           automationName: 'XCUITest',
-          app: 'bs://<ios_app_url>',
+          // custom id for the uploaded app: https://www.browserstack.com/docs/app-automate/appium/upload-app-define-custom-id
+          app: 'bs_sample_ios_app',
           platformVersion: '16',
           deviceName: 'iPhone 14'
-        }
+        },
+        appUploadPath: 'apps/ios_app.ipa'
       }
     },
   }


### PR DESCRIPTION
`appUploadPath` and `appUploadUrl` capabilities can be used to upload app automatically to BrowserStack in Nightwatch.

More details: https://github.com/nightwatchjs/nightwatch/pull/3573