### PR TITLE
Update nightwatch.conf.js

### DIFF
--- a/resources/config/nightwatch.conf.js
+++ b/resources/config/nightwatch.conf.js
@@ -22,7 +22,7 @@ const browserStack = {
 }
 
 const nightwatchConfigs = {
-  src_folders: [],
+  src_folders: ["./tests/specs/e2e/*.js"],
   live_output: true,
   plugins: ['@nightwatch/browserstack'],
   


### PR DESCRIPTION
On Windows an error is thrown if there's no value in src_folders. The --test parameter is ignored on Windows. On OS X is working without this change.